### PR TITLE
Change imports for python 3.

### DIFF
--- a/cprofilev.py
+++ b/cprofilev.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import argparse
 import bottle
@@ -7,16 +8,16 @@ import os
 import pstats
 import re
 import sys
-import tempfile
 import threading
 
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
-except ImportError:
-    # Python 3 compatibility.
-    from io import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        # Python 3 compatibility.
+        from io import StringIO
 
 
 VERSION = '1.0.0'


### PR DESCRIPTION
Rearrange try / except to import StringIO for python 3

Added \_\_future\_\_ print to be explicit since it is already being
used.

Remove unused tempfile.