### PR TITLE
Added the http:// prefix to the server address message so as to trigger clever terminal for URL

### DIFF
--- a/cprofilev.py
+++ b/cprofilev.py
@@ -193,7 +193,7 @@ def main():
         parser.print_help()
         sys.exit(2)
 
-    info = '[cProfileV]: cProfile output available at %s:%s' % \
+    info = '[cProfileV]: cProfile output available at http://%s:%s' % \
         (args.address, args.port)
 
     # v0 mode: Render profile output.


### PR DESCRIPTION
For example KTerminal provides a right click -> open link feature on the URL.