### PR TITLE
Info message is sent to stderr instead of stdout

### DIFF
--- a/cprofilev.py
+++ b/cprofilev.py
@@ -198,7 +198,7 @@ def main():
 
     # v0 mode: Render profile output.
     if args.file:
-        print(info)
+        sys.stderr.write(info + "\n")
         cprofilev = CProfileV(args.file, title=args.file, address=args.address, port=args.port)
         cprofilev.start()
         return
@@ -209,7 +209,7 @@ def main():
         parser.print_help()
         sys.exit(2)
 
-    print(info)
+    sys.stderr.write(info + "\n")
     profile = cProfile.Profile()
     progname = args.remainder[0]
     sys.path.insert(0, os.path.dirname(progname))

--- a/cprofilev.py
+++ b/cprofilev.py
@@ -198,6 +198,8 @@ def main():
 
     # v0 mode: Render profile output.
     if args.file:
+        # Note: The info message is sent to stderr to keep stdout clean in case
+        # the profiled script writes some output to stdout
         sys.stderr.write(info + "\n")
         cprofilev = CProfileV(args.file, title=args.file, address=args.address, port=args.port)
         cprofilev.start()
@@ -208,7 +210,9 @@ def main():
     if len(args.remainder) < 0:
         parser.print_help()
         sys.exit(2)
-
+        
+    # Note: The info message is sent to stderr to keep stdout clean in case
+    # the profiled script writes some output to stdout
     sys.stderr.write(info + "\n")
     profile = cProfile.Profile()
     progname = args.remainder[0]


### PR DESCRIPTION
I found that, when profiling a script which is writing some output to stdout, cprofilev info message was written at the beginning of the output file:

    # Output file is ok in this case:
    fooScript.py myInput > myOutput

    # If I want to profile the script execution:
    cprofilev fooScript.py myInput > myOutput

    # But now the first line of myOuput is:
    #[cProfileV]: cProfile output available at http://127.0.0.1:4000

In order to be able to use cprofilev while keeping the output unchanged, the info message is now written to `sys.stderr` instead of being sent to stdout with `print`.